### PR TITLE
LPS-81670 Portlet 3.0 Async: PortletAsyncContext.createAsyncListener

### DIFF
--- a/portal-impl/src/com/liferay/portlet/internal/PortletAsyncContextImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/PortletAsyncContextImpl.java
@@ -73,9 +73,12 @@ public class PortletAsyncContextImpl implements LiferayPortletAsyncContext {
 			Class<T> listenerClass)
 		throws PortletException {
 
-		// TODO
-
-		throw new UnsupportedOperationException();
+		try {
+			return listenerClass.newInstance();
+		}
+		catch (Throwable e) {
+			throw new PortletException(e);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
@ngriffin7a We can only make this simple implementation for this method. The Spec and JavaDoc requires this method to support CDI, and there are one or two TCK test cases testing it.